### PR TITLE
Use in_reply_to to reduce @usernames

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ import urllib
 LOG = logging.getLogger('english_battle_bot')
 BOTNAME = "wordsbattle"
 TARGET_TWITTERERS = ["iw_tatsu", "hamko_intel", "ompugao", "D_Plius"]
-SLEEP_TIME = 1
+SLEEP_TIME = 5
 
 
 def init_logging():


### PR DESCRIPTION
closes #8 

# 目的
リプライチェーンにすることで、@\usernames を減らすことが目的。

# ステイタス
実装はしたけど、credentials が現在は無効になっているので未テスト。新しいものをゲットしたらためしましょ〜。

# 方法
http://python-twitter.readthedocs.io/en/latest/twitter.html#twitter.api.Api.PostUpdate の
- in_reply_to_status_id

を使って、1つ前のツイートを参照するようにした。これで例えば、 
`ツイート1 (出題 3問) <- リプ1 <- リプ2 <- リプ3`
(リプ1には、ツイート1をつぶやいた人以外が @ でメンションされ、リプ2以降は @ メンションはつかない)
とつながる予定。

他の人が勝手に入るように以下を True にしてみたけど、これがちゃんと動くかテストが必要

- auto_populate_reply_metadata



# NOTE:
* ほんとうは良くないと思いつつも、早いうちにと思ってリファクタリングもちょっとしちゃった🐶
** コード自体はなるべく以前の形を保ったままメソッドに切り分けた形。
** flake8 とかを利用した。 `1行80文字以内`は守ってないものの、一通り対応。